### PR TITLE
feat: remove component handling in tags and releases

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -547,23 +547,29 @@ export class Manifest {
       }
       const component = tagName.component || DEFAULT_COMPONENT_NAME;
       const path = pathsByComponent[component];
-      if (!path) {
+      if (!path && component !== '') {
         this.logger.warn(
           `Found release tag with component '${component}', but not configured in manifest`
         );
         continue;
       }
-      const expectedVersion = this.releasedVersions[path];
+      const expectedVersion = this.releasedVersions['.'];
       if (!expectedVersion) {
         this.logger.warn(
           `Unable to find expected version for path '${path}' in manifest`
         );
         continue;
       }
-      if (expectedVersion.toString() === tagName.version.toString()) {
-        this.logger.debug(`Found release for path ${path}, ${release.tagName}`);
-        releaseShasByPath[path] = release.sha;
-        releasesByPath[path] = {
+      if (
+        expectedVersion.toString() === tagName.version.toString() ||
+        (component === '' && releasesFound < 1)
+      ) {
+        const hardCodedPath = '.';
+        this.logger.debug(
+          `Found release for path ${hardCodedPath}, ${release.tagName}`
+        );
+        releaseShasByPath[hardCodedPath] = release.sha;
+        releasesByPath[hardCodedPath] = {
           name: release.name,
           tag: tagName,
           sha: release.sha,
@@ -650,7 +656,7 @@ export class Manifest {
           `Needed bootstrapping, found configured bootstrapSha ${this.bootstrapSha}`
         );
         break;
-      } else if (!needsBootstrap && releaseCommitsFound >= expectedShas) {
+      } else if (releaseCommitsFound >= expectedShas) {
         // found enough commits
         break;
       }

--- a/src/plugins/merge.ts
+++ b/src/plugins/merge.ts
@@ -87,7 +87,7 @@ export class Merge extends ManifestPlugin {
       [[], []]
     );
 
-    const releaseData: ReleaseData[] = [];
+    let releaseData: ReleaseData[] = [];
     const labels = new Set<string>();
     let rawUpdates: Update[] = [];
     let rootRelease: CandidateReleasePullRequest | null = null;
@@ -103,6 +103,9 @@ export class Merge extends ManifestPlugin {
       }
     }
     const updates = mergeUpdates(rawUpdates);
+    if (rootRelease) {
+      releaseData = rootRelease.pullRequest.body.releaseData;
+    }
 
     const pullRequest = {
       title: PullRequestTitle.ofComponentTargetBranchVersion(
@@ -113,7 +116,7 @@ export class Merge extends ManifestPlugin {
         this.componentNoSpace
       ),
       body: new PullRequestBody(releaseData, {
-        useComponents: true,
+        useComponents: rootRelease ? false : true,
         header: this.pullRequestHeader,
         footer: this.pullRequestFooter,
       }),

--- a/src/strategies/base.ts
+++ b/src/strategies/base.ts
@@ -294,7 +294,7 @@ export abstract class BaseStrategy implements Strategy {
 
     const newVersionTag = new TagName(
       newVersion,
-      this.includeComponentInTag ? component : undefined,
+      undefined,
       this.tagSeparator,
       this.includeVInTag
     );
@@ -638,17 +638,17 @@ export abstract class BaseStrategy implements Strategy {
       pullRequestBody.releaseData.length === 1 &&
       !pullRequestBody.releaseData[0].component
     ) {
-      const branchComponent = await this.getBranchComponent();
-      // standalone release PR, ensure the components match
-      if (
-        this.normalizeComponent(branchName.component) !==
-        this.normalizeComponent(branchComponent)
-      ) {
-        this.logger.warn(
-          `PR component: ${branchName.component} does not match configured component: ${branchComponent}`
-        );
-        return;
-      }
+      // const branchComponent = await this.getBranchComponent();
+      // // standalone release PR, ensure the components match
+      // if (
+      //   this.normalizeComponent(branchName.component) !==
+      //   this.normalizeComponent(branchComponent)
+      // ) {
+      //   this.logger.warn(
+      //     `PR component: ${branchName.component} does not match configured component: ${branchComponent}`
+      //   );
+      //   return;
+      // }
       releaseData = pullRequestBody.releaseData[0];
     } else {
       // manifest release with multiple components - find the release notes
@@ -694,14 +694,11 @@ export abstract class BaseStrategy implements Strategy {
 
     const tag = new TagName(
       version,
-      this.includeComponentInTag ? component : undefined,
+      undefined,
       this.tagSeparator,
       this.includeVInTag
     );
-    const releaseName =
-      component && this.includeComponentInTag
-        ? `${component}: v${version.toString()}`
-        : `v${version.toString()}`;
+    const releaseName = `v${version.toString()}`;
     return {
       name: releaseName,
       tag,


### PR DESCRIPTION
Simplifies release flow by removing component prefixes from tags and release names. Changes enable monolithic release handling where all releases are treated as root-level without component discrimination.

Modifies tag generation to exclude component names, updates manifest logic to use root path for release tracking, and adjusts merge plugin to conditionally handle release data based on root release existence.

