### PR TITLE
feat(workspace): add dm-sdk root package version handling

### DIFF
--- a/src/plugins/workspace.ts
+++ b/src/plugins/workspace.ts
@@ -258,8 +258,11 @@ export abstract class WorkspacePlugin<T> extends ManifestPlugin {
       const packageName = this.packageNameFromPackage(pkg);
       this.logger.debug(`package: ${packageName}`);
       const existingCandidate = candidatesByPackage[packageName];
-      if (existingCandidate) {
-        const version = existingCandidate.pullRequest.version!;
+      if (existingCandidate || candidatesByPackage['dm-sdk']) {
+        const isRootRelease = packageName === 'dm-sdk';
+        const version = isRootRelease
+          ? existingCandidate.pullRequest.version!
+          : candidatesByPackage['dm-sdk'].pullRequest.version!;
         this.logger.debug(`version: ${version} from release-please`);
         updatedVersions.set(packageName, version);
       } else {


### PR DESCRIPTION
Modify WorkspacePlugin to allow packages to inherit version from dm-sdk root package when they don't have their own release candidate. This enables centralized version management where packages can use the root dm-sdk version as fallback.

- Check for dm-sdk candidate in addition to existing candidate
- Add isRootRelease flag to determine version source
- Use dm-sdk version for packages without their own candidate

